### PR TITLE
Added interpolateSelector option

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -11,6 +11,7 @@ S       = require 'string'
 defaults =
   selector: '[data-t]'
   attrSelector: '[data-attr-t]',
+  interpolateSelector: '[data-t-interpolate]',
   attrInterpolateSelector: '[data-attr-t-interpolate]',
   useAttr: true
   replace: false
@@ -125,6 +126,9 @@ translateElem = ($, elem, options, t) ->
     if options.allowHtml
       $elem.html(trans)
     else
+      if $elem.filter(otpions.interpolateSelector).length
+        trans = trans.replace /{{([^{}]*)}}/g, (aa, bb) ->
+          return t(bb)
       $elem.text(trans)
 
 getPath = (fpath, locale, options) ->

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -126,7 +126,7 @@ translateElem = ($, elem, options, t) ->
     if options.allowHtml
       $elem.html(trans)
     else
-      if $elem.filter(otpions.interpolateSelector).length
+      if $elem.filter(options.interpolateSelector).length
         trans = trans.replace /{{([^{}]*)}}/g, (aa, bb) ->
           return t(bb)
       $elem.text(trans)


### PR DESCRIPTION
Fixing problems reported in https://github.com/claudetech/node-static-i18n/issues and  https://github.com/claudetech/node-static-i18n/issues/15

It allows to do something like:

```html
<div data-t-interpolate data-t>
    {{Download}} <a href="whate">whatever</a> {{file}}
</div>
```

As well as use indentation such as 
```html 
<div data-t-interpolate data-t>
    {{Download}} 
</div>
```

Or translating text without direct wrapper:

```html
<div class="demo" data-t-interpolate>
    <div class="loading"></div>
    {{My text here}}
</div>
```