### PR TITLE
Fixed lose of HTML when using data-t-interpolate & allowHtml

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -130,7 +130,11 @@ translateElem = ($, elem, options, t) ->
       trans = trans.replace /{{([^{}]*)}}/g, (aa, bb) ->
         return t(bb)
     if options.allowHtml
-      $elem.html(trans)
+      if interpolate
+        $elem.html($elem.html().trans.replace /{{([^{}]*)}}/g, (aa, bb) ->
+          return t(bb))
+      else
+        $elem.html(trans)
     else
       $elem.text(trans)
     $elem.attr(interpolateAttr, null) if options.removeAttr && interpolate

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -131,7 +131,7 @@ translateElem = ($, elem, options, t) ->
         return t(bb)
     if options.allowHtml
       if interpolate
-        $elem.html($elem.html().trans.replace /{{([^{}]*)}}/g, (aa, bb) ->
+        $elem.html($elem.html().replace /{{([^{}]*)}}/g, (aa, bb) ->
           return t(bb))
       else
         $elem.html(trans)


### PR DESCRIPTION
HTML code would get lost when having something like this:

```
<p data-t data-t-interpolate>
  {{Test}}
    <br />Whatever<br />here<br /><br /><br /><br />
</p>
```

This solves the issue.