### PR TITLE
Update index.coffee

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -115,9 +115,15 @@ translateAttributes = ($elem, options, t) ->
 
 translateElem = ($, elem, options, t) ->
   $elem = $(elem)
-  if options.useAttr && attr = /^\[(.*?)\]$/.exec(options.selector)
-    key = $elem.attr(attr[1])
-    $elem.attr(attr[1], null) if options.removeAttr
+  if options.useAttr
+  [
+    options.selector
+    options.interpolateSelector
+  ].forEach (selectorString) ->
+    if attr = /^\[(.*?)\]$/.exec(selectorString)
+      key = $elem.attr(attr[1])
+      if options.removeAttr
+        $elem.attr attr[1], null
   key = $elem.text() if _.isEmpty(key)
   return if _.isEmpty(key)
   trans = t(key)


### PR DESCRIPTION
Removes `data-t-interpolate` attribute. So instead of:

```html
<p data-t-interpolate="">
    texto aqui
    <div>Whatever here</div>
</p>
```

It creates
```html
<p>
    texto aqui
    <div>Whatever here</div>
</p>
```

Please review the code changes as my knowledge in cofeescript is far from ideal :)