### PR TITLE
Use locale as root key in translation source files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 
 .nyc_output/
 coverage/
+
+.DS_Store

--- a/bin/static-i18n.js
+++ b/bin/static-i18n.js
@@ -15,7 +15,8 @@ const minimistOptions = {
     'xml',
     'allowHtml',
     'version',
-    'help'
+    'help',
+    'localeRootKey'
   ],
   string: [
     'locale',
@@ -23,7 +24,7 @@ const minimistOptions = {
     'outputDir',
     'outputDefault',
     'outputOther',
-    'locales'
+    'locales',
   ],
   alias: {
     l: 'locale',
@@ -33,6 +34,8 @@ const minimistOptions = {
     o: 'outputDir',
     v: 'version',
     h: 'help',
+    r: 'localeRootKey',
+    'root-key': 'rootKey',
     'output-dir': 'outputDir',
     'base-dir': 'baseDir',
     'translate-conditional-comments': 'translateConditionalComments',
@@ -45,6 +48,7 @@ const minimistOptions = {
     'allow-html': 'allowHtml'
   },
   default: {
+    localeRootKey: false,
     useAttr: true,
     fixPaths: true,
     replace: false,
@@ -65,6 +69,7 @@ const usageText = [
   '-o, --output-dir\toutput directory (default: i18n)',
   '-v, --version\t\tprints version and exits',
   '-h, --help\t\tprints this help and exits',
+  '-r, --root-key\t\tuse locale as source file root key',
   '',
   'Please check the README for more information:',
   'https://github.com/claudetech/node-static-i18n'

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,7 @@ const defaults = {
   outputOther: '__lng__/__file__',
   localesPath: 'locales',
   outputOverride: {},
+  localeRootKey: false,
   encoding: 'utf8',
   translateConditionalComments: false,
   i18n: {
@@ -58,13 +59,13 @@ function promisify(func, ignoreError) {
   };
 }
 
-function parseTranslations(format, rawTranslations) {
+function parseTranslations(format, rawTranslations, localeRootKey, locale) {
   switch (format) {
     case '.yml':
     case '.yaml':
-      return yaml.load(rawTranslations);
+      return localeRootKey ? yaml.load(rawTranslations)[locale] : yaml.load(rawTranslations);
     case '.json':
-        return JSON.parse(rawTranslations);
+      return localeRootKey ? JSON.parse(rawTranslations)[locale] : JSON.parse(rawTranslations);
     default:
       throw new Error('unknown format');
   }
@@ -74,7 +75,7 @@ function loadResources(locale, options) {
   const file = path.join(options.localesPath, options.localeFile).replace('__lng__', locale);
   const extension = path.extname(file);
   return fs.readFile(file, options.encoding)
-           .then(data => parseTranslations(extension, data));
+           .then(data => parseTranslations(extension, data, options.localeRootKey, locale));
 }
 
 function getOptions(baseOptions) {
@@ -347,3 +348,4 @@ exports.processDir = function(dir, options) {
       return _(results).fromPairs().mapKeys((_v, f) => path.relative(dir, f)).value();
     });
 };
+


### PR DESCRIPTION
I'm using a [translation tool](https://translation.io/) which generates me my translation files.
It generates my files but he uses the locale as the root key of my translations : 
For `en.yml`
```
  en: 
    title: Hello
    ...
```

and  for `fr.yml`

```
  fr: 
    title: Bonjour
    ...
```

So I propose to add an option to pass in order to handle this.