### PR TITLE
Add the locale inside the error message

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -60,14 +60,19 @@ function promisify(func, ignoreError) {
 }
 
 function parseTranslations(format, rawTranslations, localeRootKey, locale) {
-  switch (format) {
-    case '.yml':
-    case '.yaml':
-      return localeRootKey ? yaml.load(rawTranslations)[locale] : yaml.load(rawTranslations);
-    case '.json':
-      return localeRootKey ? JSON.parse(rawTranslations)[locale] : JSON.parse(rawTranslations);
-    default:
-      throw new Error('unknown format');
+  try {
+    switch (format) {
+      case '.yml':
+      case '.yaml':
+        return localeRootKey ? yaml.load(rawTranslations)[locale] : yaml.load(rawTranslations);
+      case '.json':
+        return localeRootKey ? JSON.parse(rawTranslations)[locale] : JSON.parse(rawTranslations);
+      default:
+        throw new Error('unknown format');
+    }
+  } catch (e) {
+    e.message = ['[', locale, '] ', e.message].join('');
+    throw e;
   }
 }
 


### PR DESCRIPTION
:wave: there is an issue with the errors.

The current error message when a parsing fails doesn't give you enough informations.
Ex: for a merge issue inside a JSON (we have 10s locales):
```
Unexpected token < in JSON at position 318
```

With the fix you have the locale: 
![Screenshot from 2020-02-17 16-04-20](https://user-images.githubusercontent.com/713283/74665627-5e7ba480-51a0-11ea-9f94-6a89208069d5.png)
