### PR TITLE
Add nsSeparator CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ static-i18n --attr-selector my-attr-t ...
 * `attrSuffix` (default: `-t`): Suffix for attr to translate. `value-t` will be translated and mapped to `value`.
 * `attrInterpolateSuffix` (default: `-t-interpolate`): Suffix for attr to interpolate the translations.
 * `useAttr` (default: `true`): If `false`, the element text is always used as the key, even if the attribute value is not empty.
+* `nsSeparator` (default: `:`): The namespace separator. Useful if keys contain colons. Change it to something else to prevent cutting off the namespace.
 * `replace` (default: `false`): If `true`, the element is replaced by the translation. Useful to use something like `<t>my.key</t>` to translate.
 * `locales` (default: `['en']`, CLI alias: `-i`): the list of locales to be generated.
   All locales need to have an existing resource file.

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,7 @@ const defaults = {
   localesPath: 'locales',
   outputOverride: {},
   localeRootKey: false,
+  nsSeparator: ":",
   encoding: 'utf8',
   translateConditionalComments: false,
   i18n: {

--- a/test/data/locales/ja.json
+++ b/test/data/locales/ja.json
@@ -3,6 +3,9 @@
     "bar": "ja_bar",
     "baz": "ja_baz"
   },
+  "ns:boo": {
+    "namespace:zoo": "ja_wow"
+  },
   "links": {
       "baseAbsolute": "http://www.example.com/ja/",
       "extension": "htm"

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -84,6 +84,13 @@ describe('processor', function() {
       const results = await staticI18n.process(input, options);
       expect(results.en).to.equal(input);
     });
+
+    it('should handle namespace separator', async function() {
+      options = _.merge({}, options, {nsSeparator: '#', locales: ['ja']});
+      const input = '<p data-t="ns:boo.namespace:zoo"></p>';
+      const results = await staticI18n.process(input, options);
+      expect(results.ja).to.be('<p>ja_wow</p>');
+    });
   });
 
   describe('#processFile', function() {


### PR DESCRIPTION
I have colons in my keys.
This option lets me stop treating ":" as the namespace separator.