### PR TITLE
Treat URLs like data:image/svg+xml as absolute to support inlining images in html

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,7 @@ const defaults = {
   }
 };
 
-const absolutePathRegex = new RegExp('^(?:[a-z]+:)?//', 'i');
+const absolutePathRegex = new RegExp('^(?:[a-z]+:)?//|^data:image/[^;]+;', 'i');
 const conditionalCommentRegex = /(\s*\[if .*?\]\s*>\s*)(.*?)(\s*<!\s*\[endif\]\s*)/i;
 const closingTagRegex = /<\/.+?>/g;
 

--- a/test/data/index.html
+++ b/test/data/index.html
@@ -16,6 +16,7 @@
 </head>
 <body>
   <img id="abs-img" src="//foo.png" />
+  <img id="abs-img-data" src="data:image/svg+xml;base64,foo" />
   <img id="rel-img" src="foo.png" />
 
   <audio id="abs-audio" src="//foo.mp3"></audio>
@@ -26,10 +27,12 @@
 
   <picture>
     <source id="abs-source" src="//foo.jpg"></source>
+    <source id="abs-source-data" src="data:image/svg+xml;base64,foo"></source>
     <source id="rel-source" src="foo.jpg"></source>
   </picture>
 
   <div id="abs-style" style="background-image: url(//bg.jpg); background: url('//bg.jpg')"></div>
+  <div id="abs-style-data" style="background-image: url(data:image/svg+xml;base64,foo); background: url('data:image/svg+xml;base64,foo')"></div>
   <div id="rel-style" style="background-image: url(bg.jpg); background: url('bg.jpg')"></div>
 
   <!--[if lt IE 9]>

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -227,6 +227,7 @@ describe('processor', function () {
 
       expect($('#rel-img').attr('src')).to.be('../foo.png');
       expect($('#abs-img').attr('src')).to.be('//foo.png');
+      expect($('#abs-img-data').attr('src')).to.be('data:image/svg+xml;base64,foo');
 
       expect($('#rel-audio').attr('src')).to.be('../foo.mp3');
       expect($('#abs-audio').attr('src')).to.be('//foo.mp3');
@@ -236,12 +237,16 @@ describe('processor', function () {
 
       expect($('#rel-source').attr('src')).to.be('../foo.jpg');
       expect($('#abs-source').attr('src')).to.be('//foo.jpg');
+      expect($('#abs-source-data').attr('src')).to.be('data:image/svg+xml;base64,foo');
 
       expect($('#rel-style').attr('style')).to.be(
         "background-image: url('../bg.jpg'); background: url('../bg.jpg')"
       );
       expect($('#abs-style').attr('style')).to.be(
         "background-image: url(//bg.jpg); background: url('//bg.jpg')"
+      );
+      expect($('#abs-style-data').attr('style')).to.be(
+        "background-image: url(data:image/svg+xml;base64,foo); background: url('data:image/svg+xml;base64,foo')"
       );
 
       $ = cheerio.load(fs.readFileSync(path.join(dir, 'index.html'), 'utf8'));


### PR DESCRIPTION
Currently a URL like `data:image/svg+xml;base64,foo` is considered a relative URL, which means that an image tag like this:
```
<img src="data:image/svg+xml;base64,foo" />
```
gets re-written to
```
<img src="../data:image/svg+xml;base64,foo" />
```
which of course is not supported by the browser.

This PR fixes this issue by adjusting the `absolutePathRegex` to consider URLs that start with the format `data:image/<image-format>;` as absolute as well.

This solution could potentially be expanded to be more general and treat anything that starts with `data:` as an absolute url. I am unsure about the use cases though, and opted for a less generic solution.